### PR TITLE
Ft/zenko 160 add lvm storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /*.retry
 /venv
+/host_vars

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /*.retry
 /venv
 /host_vars
+/inventories

--- a/metal-k8s.yml
+++ b/metal-k8s.yml
@@ -14,6 +14,14 @@
   roles:
     - role: setup_lvm
 
+- hosts: k8s-cluster
+  gather_facts: False
+  tags:
+    - kubespray
+  roles:
+    - role: kubespray/roles/kubespray-defaults/
+    - role: kubespray_var_patcher
+
 - import_playbook: 'kubespray/cluster.yml'
   tags: kubespray
 

--- a/metal-k8s.yml
+++ b/metal-k8s.yml
@@ -8,8 +8,20 @@
   roles:
     - role: python2_install
 
+- hosts: kube-node
+  tags:
+    - lvm-storage
+  roles:
+    - role: setup_lvm
+
 - import_playbook: 'kubespray/cluster.yml'
   tags: kubespray
+
+- hosts: kube-node
+  tags:
+    - lvm-storage
+  roles:
+    - role: kube_lvm_storage
 
 - hosts: kube-master
   gather_facts: False

--- a/roles/kube_lvm_storage/defaults/main.yml
+++ b/roles/kube_lvm_storage/defaults/main.yml
@@ -1,6 +1,51 @@
 debug: False
 
-lvm_mount_prefix: '/mnt/lvm'
-
 local_volume_provisioner_image_repo: quay.io/external_storage/local-volume-provisioner
 local_volume_provisioner_image_tag: v2.0.0
+
+# ################ #
+# LVM confguration #
+# ################ #
+#
+# Specify which VG and which drive to use in host_vars for each node
+metal_k8s_lvm:
+  vgs:
+    kubevg:
+      drives: []
+
+# Set the storage class setup on kubernetes node
+# possible values are "lvm" or "local-storage"
+metal_k8s_storage_class:
+  type: "lvm"
+  lvm:
+    default_fstype: 'ext4'
+    default_fs_force: False
+    default_fs_opts: '-m 0'
+    default_mount_opts: 'defaults'
+    vgs:
+      kubevg:
+        volumes:
+          - name: lv01
+            size: 10G
+          - name: lv02
+            size: 10G
+          - name: lv03
+            size: 10G
+          - name: lv04
+            size: 10G
+          - name: lv05
+            size: 10G
+        host_path: '/mnt/kubevg'
+
+#
+# You can also customize a specific volume like this
+#
+#    vgs:
+#      kubevg:
+#        volumes:
+#          - name: lv01
+#            size: 10G
+#            fstype: xfs
+#            fs_force: True
+#            fs_opts: '-m 0 -cc'
+#            mount_opts: 'defaults,noatime'

--- a/roles/kube_lvm_storage/defaults/main.yml
+++ b/roles/kube_lvm_storage/defaults/main.yml
@@ -10,14 +10,18 @@ local_volume_provisioner_image_tag: v2.0.0
 # Set the storage class setup on kubernetes node
 # possible values are "lvm" or "local-storage"
 metal_k8s_storage_class:
-  type: "lvm"
-  lvm:
+  storage_classes:
+    local-lvm:
+      is_default: true
+  lvm_conf:
     default_fstype: 'ext4'
     default_fs_force: False
     default_fs_opts: '-m 0'
     default_mount_opts: 'defaults'
     vgs:
       kubevg:
+        host_path: '/mnt/kubevg'
+        storage_class: 'local-lvm'
         volumes:
           - name: lv01
             size: 10G
@@ -29,7 +33,6 @@ metal_k8s_storage_class:
             size: 10G
           - name: lv05
             size: 10G
-        host_path: '/mnt/kubevg'
 
 #
 # You can also customize a specific volume like this

--- a/roles/kube_lvm_storage/defaults/main.yml
+++ b/roles/kube_lvm_storage/defaults/main.yml
@@ -1,0 +1,6 @@
+debug: False
+
+lvm_mount_prefix: '/mnt/lvm'
+
+local_volume_provisioner_image_repo: quay.io/external_storage/local-volume-provisioner
+local_volume_provisioner_image_tag: v2.0.0

--- a/roles/kube_lvm_storage/defaults/main.yml
+++ b/roles/kube_lvm_storage/defaults/main.yml
@@ -6,12 +6,6 @@ local_volume_provisioner_image_tag: v2.0.0
 # ################ #
 # LVM confguration #
 # ################ #
-#
-# Specify which VG and which drive to use in host_vars for each node
-metal_k8s_lvm:
-  vgs:
-    kubevg:
-      drives: []
 
 # Set the storage class setup on kubernetes node
 # possible values are "lvm" or "local-storage"

--- a/roles/kube_lvm_storage/tasks/main.yml
+++ b/roles/kube_lvm_storage/tasks/main.yml
@@ -1,0 +1,140 @@
+- name: 'assert all vgs have a host_path and volumes defined'
+  assert:
+    that:
+      - item.value.volumes|length > 0
+      - item.value.host_path|default("") != ""
+  with_dict: '{{ metal_k8s_storage_class.lvm.vgs }}'
+
+- name: 'create dir for lvm storage'
+  file:
+    dest: '{{ item.value.host_path }}'
+    state: directory
+  with_dict: '{{ metal_k8s_storage_class.lvm.vgs }}'
+
+- name: display vgs in metal_k8s_storage_class
+  debug:
+    msg: '{{ metal_k8s_storage_class.lvm.vgs }}'
+
+#
+# Set a dictionary that will be used for the LVM configuration
+# based on the metal_k8s_storage_class var
+#
+#   ..code::
+#
+#     {
+#         '/dev/mapper/kubevg-lv01' : {
+#             'host_path': '/mnt/kubevg',
+#             'vg': 'kubevg',
+#             'volume': {
+#                 'name': 'lv01',
+#                 'fstype': 'ext4',
+#                 'size': '10G',
+#                 'fs_force': False,
+#                 'fs_opts': "",
+#                 'mount_opts': "",
+#             },
+#         }
+#     }
+#
+
+- name: set fact with metal_k8s_storage_class attributes
+  set_fact:
+    metal_k8s_lvm_conf: >-
+      {
+        {%- for vg, prop in metal_k8s_storage_class.lvm.vgs.items() -%}
+          {%- set host_path = prop.host_path -%}
+          {%- for volume in prop.volumes -%}
+            {%- set _ = volume.update(
+              {'fstype': volume.fstype
+                |default(metal_k8s_storage_class.lvm.default_fstype)}) -%}
+            {%- set _ = volume.update(
+              {'fs_force': volume.fs_force
+                |default(metal_k8s_storage_class.lvm.default_fs_force)}) -%}
+            {%- set _ = volume.update(
+              {'fs_opts': volume.fs_opts
+                |default(metal_k8s_storage_class.lvm.default_fs_opts)}) -%}
+            {%- set _ = volume.update(
+              {'mount_opts': volume.mount_opts
+                |default(metal_k8s_storage_class.lvm.default_mount_opts)}) -%}
+            {%- set device = '/dev/mapper/' ~ vg ~ '-'
+              ~ volume.name.replace("-", "--") -%}
+            '{{ device }}': {{ dict(vg=vg,
+                volume=volume, host_path=host_path) }},
+          {%- endfor -%}
+        {%- endfor -%}
+      }
+
+- name: display metal_k8s_lvm_conf dictionary
+  debug:
+    msg: '{{ metal_k8s_lvm_conf }}'
+
+- name: 'create lvm volumes with required size for each vg'
+  lvol:
+    lv: '{{ item.value.volume.name }}'
+    vg: '{{ item.value.vg }}'
+    size: '{{ item.value.volume.size }}'
+    state: present
+    shrink: False
+  with_dict: '{{ metal_k8s_lvm_conf }}'
+
+- name: 'create filesystem on each lvm volumes'
+  filesystem:
+    fstype: '{{ item.value.volume.fstype }}'
+    dev: '{{ item.key }}'
+    opts: '{{ item.value.volume.fs_opts }}'
+    force: '{{ item.value.volume.fs_force }}'
+  with_dict: '{{ metal_k8s_lvm_conf }}'
+
+- name: 'get UUIDs of lvm volumes'
+  shell: |
+    blkid -s UUID -o value {{ item.key }}
+  register: metal_k8s_lvm_uuids
+  with_dict: '{{ metal_k8s_lvm_conf }}'
+
+- name: display UUIDs
+  debug:
+    msg: '{{ metal_k8s_lvm_uuids.results }}'
+
+# Update metal_k8s_conf with UUIDs of the filesystems
+#
+#   ..code::
+#
+#     {
+#         '/dev/mapper/kubevg-lv01' : {
+#             'host_path': '/mnt/kubevg',
+#             'vg': 'kubevg',
+#             'volume': {
+#                 'name': 'lv01',
+#                 'fstype': 'ext4',
+#                 'size': '10G',
+#                 'uuid': 'xxxx-yyyy'
+#             },
+#         }
+#     }
+
+- name: update fact metal_k8s_lvm_conf with UUIDs
+  set_fact:
+    metal_k8s_lvm_conf: >-
+      {
+        {%- for device, prop in metal_k8s_lvm_conf.items() -%}
+          {%- for result in metal_k8s_lvm_uuids.results -%}
+            {%- if result.item.key == device -%}
+              {%- set _ =  prop.volume.update({'uuid': result.stdout}) -%}
+              '{{ device }}': {{ prop }},
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endfor -%}
+      }
+
+- name: display metal_k8s_lvm_conf dictionary with UUIDs
+  debug:
+    msg: '{{ metal_k8s_lvm_conf }}'
+
+- name: 'mount filesystem for each lvm volumes'
+  mount:
+    path: '{{ item.value.host_path }}/{{ item.value.volume.uuid }}'
+    src: UUID={{ item.value.volume.uuid }}
+    opts: '{{ item.value.volume.mount_opts }}'
+    fstype: '{{ item.value.volume.fstype }}'
+    state: mounted
+  with_dict: '{{ metal_k8s_lvm_conf }}'

--- a/roles/kube_lvm_storage/tasks/main.yml
+++ b/roles/kube_lvm_storage/tasks/main.yml
@@ -51,18 +51,23 @@
             {%- set _ = volume.update(
               {'fs_force': volume.fs_force
                 |default(
-                    metal_k8s_storage_class.lvm_conf.default_fs_force
+                  metal_k8s_storage_class.lvm_conf.default_fs_force
                 )}) -%}
             {%- set _ = volume.update(
               {'fs_opts': volume.fs_opts
-                |default(metal_k8s_storage_class.lvm_conf.default_fs_opts)}) -%}
+                |default(
+                    metal_k8s_storage_class.lvm_conf.default_fs_opts)}) -%}
             {%- set _ = volume.update(
               {'mount_opts': volume.mount_opts
-                |default(metal_k8s_storage_class.lvm_conf.default_mount_opts)}) -%}
+                |default(
+                  metal_k8s_storage_class.lvm_conf.default_mount_opts)}) -%}
             {%- set device = '/dev/mapper/' ~ vg ~ '-'
               ~ volume.name.replace("-", "--") -%}
             '{{ device }}': {{ dict(vg=vg,
-                volume=volume, host_path=host_path) }},
+                volume=volume,
+                host_path=prop.host_path,
+                storage_class=prop.storage_class,)
+             }},
           {%- endfor -%}
         {%- endfor -%}
       }
@@ -151,9 +156,13 @@
       - 'item.value.storage_class'
   with_dict: '{{ metal_k8s_storage_class.lvm_conf.vgs }}'
 
-- name: 'Create the local LVM based StorageClass'
+- name: 'Create the Kubernetes resources | StorageClass'
+  delegate_to: localhost
+  run_once: True
+  with_dict: '{{ metal_k8s_storage_class.storage_classes }}'
   k8s_raw:
     state: present
+    kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
     definition:
       apiVersion: v1
       kind: StorageClass
@@ -163,5 +172,37 @@
           storageclass.kubernetes.io/is-default-class: '{{ item.value.is_default|default(False)|string }}'
       provisioner: kubernetes.io/no-provisioner
       volumeBindingMode: WaitForFirstConsumer
-  with_dict: '{{ metal_k8s_storage_class.storage_classes }}'
+
+- name: 'Create the Kubernetes resources | PVs'
   delegate_to: localhost
+  with_dict: '{{ metal_k8s_lvm_conf }}'
+  k8s_raw:
+    state: present
+    kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+    definition:
+      apiVersion: v1
+      kind: PersistentVolume
+      metadata:
+        name: >-
+          {{ item.value.vg|replace("_","-") }}-{{ item.value.volume.uuid }}
+        annotations:
+          "volume.alpha.kubernetes.io/node-affinity": ' {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "nodeSelectorTerms": [
+                      { "matchExpressions": [
+                          { "key": "kubernetes.io/hostname",
+                            "operator": "In",
+                            "values": ["{{ ansible_hostname }}"]
+                          }
+                      ]}
+                   ]}
+                }'
+      spec:
+        capacity:
+          storage: '{{ item.value.volume.size }}'
+        accessModes:
+        - ReadWriteOnce
+        persistentVolumeReclaimPolicy: Delete
+        storageClassName: '{{ item.value.storage_class }}'
+        local:
+          path: '{{ item.value.host_path }}/{{ item.value.volume.uuid }}'

--- a/roles/kube_lvm_storage/tasks/main.yml
+++ b/roles/kube_lvm_storage/tasks/main.yml
@@ -1,19 +1,19 @@
-- name: 'assert all vgs have a host_path and volumes defined'
+- name: 'Assert all vgs have a host_path and volumes defined'
   assert:
     that:
       - item.value.volumes|length > 0
       - item.value.host_path|default("") != ""
-  with_dict: '{{ metal_k8s_storage_class.lvm.vgs }}'
+  with_dict: '{{ metal_k8s_storage_class.lvm_conf.vgs }}'
 
 - name: 'create dir for lvm storage'
   file:
     dest: '{{ item.value.host_path }}'
     state: directory
-  with_dict: '{{ metal_k8s_storage_class.lvm.vgs }}'
+  with_dict: '{{ metal_k8s_storage_class.lvm_conf.vgs }}'
 
 - name: display vgs in metal_k8s_storage_class
   debug:
-    msg: '{{ metal_k8s_storage_class.lvm.vgs }}'
+    msg: '{{ metal_k8s_storage_class.lvm_conf.vgs }}'
   when: debug|bool
 
 #
@@ -42,21 +42,23 @@
   set_fact:
     metal_k8s_lvm_conf: >-
       {
-        {%- for vg, prop in metal_k8s_storage_class.lvm.vgs.items() -%}
+        {%- for vg, prop in metal_k8s_storage_class.lvm_conf.vgs.items() -%}
           {%- set host_path = prop.host_path -%}
           {%- for volume in prop.volumes -%}
             {%- set _ = volume.update(
               {'fstype': volume.fstype
-                |default(metal_k8s_storage_class.lvm.default_fstype)}) -%}
+                |default(metal_k8s_storage_class.lvm_conf.default_fstype)}) -%}
             {%- set _ = volume.update(
               {'fs_force': volume.fs_force
-                |default(metal_k8s_storage_class.lvm.default_fs_force)}) -%}
+                |default(
+                    metal_k8s_storage_class.lvm_conf.default_fs_force
+                )}) -%}
             {%- set _ = volume.update(
               {'fs_opts': volume.fs_opts
-                |default(metal_k8s_storage_class.lvm.default_fs_opts)}) -%}
+                |default(metal_k8s_storage_class.lvm_conf.default_fs_opts)}) -%}
             {%- set _ = volume.update(
               {'mount_opts': volume.mount_opts
-                |default(metal_k8s_storage_class.lvm.default_mount_opts)}) -%}
+                |default(metal_k8s_storage_class.lvm_conf.default_mount_opts)}) -%}
             {%- set device = '/dev/mapper/' ~ vg ~ '-'
               ~ volume.name.replace("-", "--") -%}
             '{{ device }}': {{ dict(vg=vg,
@@ -142,3 +144,24 @@
     fstype: '{{ item.value.volume.fstype }}'
     state: mounted
   with_dict: '{{ metal_k8s_lvm_conf }}'
+
+- name: 'Assert each LVM Vgs has a StorageClass name'
+  assert:
+    that:
+      - 'item.value.storage_class'
+  with_dict: '{{ metal_k8s_storage_class.lvm_conf.vgs }}'
+
+- name: 'Create the local LVM based StorageClass'
+  k8s_raw:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: StorageClass
+      metadata:
+        name: '{{ item.key }}'
+        annotations:
+          storageclass.kubernetes.io/is-default-class: '{{ item.value.is_default|default(False)|string }}'
+      provisioner: kubernetes.io/no-provisioner
+      volumeBindingMode: WaitForFirstConsumer
+  with_dict: '{{ metal_k8s_storage_class.storage_classes }}'
+  delegate_to: localhost

--- a/roles/kube_lvm_storage/tasks/main.yml
+++ b/roles/kube_lvm_storage/tasks/main.yml
@@ -14,6 +14,7 @@
 - name: display vgs in metal_k8s_storage_class
   debug:
     msg: '{{ metal_k8s_storage_class.lvm.vgs }}'
+  when: debug|bool
 
 #
 # Set a dictionary that will be used for the LVM configuration
@@ -67,6 +68,7 @@
 - name: display metal_k8s_lvm_conf dictionary
   debug:
     msg: '{{ metal_k8s_lvm_conf }}'
+  when: debug|bool
 
 - name: 'create lvm volumes with required size for each vg'
   lvol:
@@ -94,6 +96,7 @@
 - name: display UUIDs
   debug:
     msg: '{{ metal_k8s_lvm_uuids.results }}'
+  when: debug|bool
 
 # Update metal_k8s_conf with UUIDs of the filesystems
 #
@@ -129,6 +132,7 @@
 - name: display metal_k8s_lvm_conf dictionary with UUIDs
   debug:
     msg: '{{ metal_k8s_lvm_conf }}'
+  when: debug|bool
 
 - name: 'mount filesystem for each lvm volumes'
   mount:

--- a/roles/kube_lvm_storage/templates/clusterrolebinding.yml.j2
+++ b/roles/kube_lvm_storage/templates/clusterrolebinding.yml.j2
@@ -1,0 +1,28 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: {{ system_namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: local-storage-admin
+    namespace: {{ system_namespace }}
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: {{ system_namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: local-storage-admin
+    namespace: {{ system_namespace }}
+roleRef:
+  kind: ClusterRole
+  name: system:node
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/kube_lvm_storage/templates/configmap.yml.j2
+++ b/roles/kube_lvm_storage/templates/configmap.yml.j2
@@ -1,0 +1,13 @@
+---
+# The config map is used to configure local volume discovery for Local SSDs on GCE and GKE.
+# It is a map from storage class to its mount configuration.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-volume-config
+  namespace: {{ system_namespace }}
+data:
+  storageClassMap: |
+    {{ local_volume_storage_class }}:
+      hostDir: "{{ local_volume_base_dir }}"
+      mountDir: "{{ local_volume_mount_dir }}"

--- a/roles/kube_lvm_storage/templates/daemonset.yml.j2
+++ b/roles/kube_lvm_storage/templates/daemonset.yml.j2
@@ -1,0 +1,45 @@
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: local-volume-provisioner
+  namespace: "{{ system_namespace }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      containers:
+        - name: provisioner
+          image: {{ local_volume_provisioner_image_repo }}:{{ local_volume_provisioner_image_tag }}
+          imagePullPolicy: {{ k8s_image_pull_policy }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: discovery-vol
+              mountPath: "{{ local_volume_mount_dir }}"
+            - name: local-volume-config
+              mountPath: /etc/provisioner/config/
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: MY_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: VOLUME_CONFIG_NAME
+              value: "local-volume-config"
+      volumes:
+        - name: discovery-vol
+          hostPath:
+            path: "{{ local_volume_base_dir }}"
+        - configMap:
+            defaultMode: 420
+            name: local-volume-config
+          name: local-volume-config
+      serviceAccount: local-storage-admin

--- a/roles/kube_lvm_storage/templates/local-storageclass.yml.j2
+++ b/roles/kube_lvm_storage/templates/local-storageclass.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/roles/kube_lvm_storage/templates/serviceaccount.yml.j2
+++ b/roles/kube_lvm_storage/templates/serviceaccount.yml.j2
@@ -1,0 +1,5 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: local-storage-admin

--- a/roles/kubespray_var_patcher/defaults/main.yml
+++ b/roles/kubespray_var_patcher/defaults/main.yml
@@ -1,0 +1,3 @@
+debug: False
+
+local_volume: True

--- a/roles/kubespray_var_patcher/meta/main.yml
+++ b/roles/kubespray_var_patcher/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/roles/kubespray_var_patcher/tasks/main.yml
+++ b/roles/kubespray_var_patcher/tasks/main.yml
@@ -1,0 +1,8 @@
+- debug: var=kube_feature_gates
+  when: debug|bool
+
+- name: 'Add MountPropagation feature gate'
+  set_fact:
+    kube_feature_gates: >-
+        {{ kube_feature_gates + ['PersistentLocalVolumes=true', 'MountPropagation=true', 'VolumeScheduling=true'] }}
+  when: local_volume|bool

--- a/roles/setup_lvm/defaults/main.yml
+++ b/roles/setup_lvm/defaults/main.yml
@@ -1,0 +1,11 @@
+debug: False
+
+# ################ #
+# LVM confguration #
+# ################ #
+
+# Specify which VG and which drive to use in host_vars for each node
+metal_k8s_lvm:
+  vgs:
+    kubevg:
+      drives: []

--- a/roles/setup_lvm/meta/main.yml
+++ b/roles/setup_lvm/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/roles/setup_lvm/tasks/main.yml
+++ b/roles/setup_lvm/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: assert {{ inventory_hostname }} has vgs correctly declared
+  assert:
+    that:
+      - 'item.value.drives|length > 0'
+  with_dict: '{{ metal_k8s_lvm.vgs }}'
+
+- name: start lvm storage setup
+  debug:
+    msg: "Start LVM storage setup"
+
+- name: display metal_k8s_lvm config
+  debug:
+    msg: '{{ metal_k8s_lvm.vgs }}'
+  when: debug|bool
+
+- name: create the vgs
+  lvg:
+    pvs: '{{ item.value.drives|join(",") }}'
+    vg: '{{ item.key }}'
+    state: present
+  with_dict: '{{ metal_k8s_lvm.vgs }}'


### PR DESCRIPTION
This PR brings the setup of an local LVM based storage for K8S PVs.

You need to setup either group_vars file or host_vars files containing the attributes found into roles/setup_lvm/defaults/main.yml and roles/kube_lvm_storage/defaults/main.yml

```
# ################ #
# LVM confguration #
# ################ #

# Specify which VG and which drive to use in host_vars for each node
metal_k8s_lvm:
  vgs:
    kubevg:
      drives: []


# Set the storage class setup on kubernetes node
metal_k8s_storage_class:
  storage_classes:
    local-lvm:
      is_default: true
  lvm_conf:
    default_fstype: 'ext4'
    default_fs_force: False
    default_fs_opts: '-m 0'
    default_mount_opts: 'defaults'
    vgs:
      kubevg:
        host_path: '/mnt/kubevg'
        storage_class: 'local-lvm'
        volumes:
          - name: lv01
            size: 10G
          - name: lv02
            size: 10G
          - name: lv03
            size: 10G
          - name: lv04
            size: 10G
          - name: lv05
            size: 10G

#
# You can also customize a specific volume like this
#
#    vgs:
#      kubevg:
#        volumes:
#          - name: lv01
#            size: 10G
#            fstype: xfs
#            fs_force: True
#            fs_opts: '-m 0 -cc'
#            mount_opts: 'defaults,noatime'
```        
