### PR TITLE
Changed proxy_timeout to 3s

### DIFF
--- a/kubespray/roles/kubernetes/node/templates/nginx.conf.j2
+++ b/kubespray/roles/kubernetes/node/templates/nginx.conf.j2
@@ -18,7 +18,7 @@ stream {
         server {
             listen        127.0.0.1:{{ nginx_kube_apiserver_port|default(kube_apiserver_port) }};
             proxy_pass    kube_apiserver;
-            proxy_timeout 10m;
+            proxy_timeout 3s;
             proxy_connect_timeout 1s;
 
         }


### PR DESCRIPTION
Note (@NicolasT): this patch was retrieved from
kubernetes-incubator/kubespray#2151. See scality/metal-k8s#18 for more
background. Given the historical tickets, this change should be OK for
current `metal-k8s` deployments which are of relatively small scale, and
frequent SSL handshakes shouldn't overwhelm master nodes.

See: https://github.com/kubernetes-incubator/kubespray/pull/2151
See: https://github.com/kubernetes-incubator/kubespray/pull/2151/commits/2c74109db19a89470381cfe24a7af94314c9f581
See: https://github.com/scality/metal-k8s/issues/18
See: https://github.com/kubernetes-incubator/kubespray/issues/2150
See: https://github.com/kubernetes-incubator/kubespray/issues/655
See: https://github.com/kubernetes-incubator/kubespray/pull/656