### PR TITLE
Fix `make shell` on Darwin/OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ KUBECTL = $(VENV_BIN)/kubectl
 $(KUBECTL): $(KUBECTL_BIN) $(VENV_EXISTS)
 	@ln -sf $(shell realpath $(KUBECTL_BIN)) $@
 
-HELM_SRC_TAR = $(SHELL_ENV)/$(shell basename $HELM_SRC)
+HELM_SRC_TAR = $(SHELL_ENV)/$(shell basename $(HELM_SRC))
 $(HELM_SRC_TAR): $(SHELL_ENV_EXISTS)
 	@rm -f $@.tmp
 	@echo "Downloading Helm..."

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PYTHON_VIRTUALENV_SRC = $(SHELL_ENV)/$(shell basename $(VIRTUALENV_SRC))
 $(PYTHON_VIRTUALENV_SRC): $(SHELL_ENV_EXISTS)
 	@rm -f $@.tmp
 	@$(PYTHON) hack/download.py $(VIRTUALENV_SRC) $@.tmp
-	@echo $(VIRTUALENV_SRC_SHA256SUM)  $@.tmp | sha256sum -c > /dev/null
+	@echo $(VIRTUALENV_SRC_SHA256SUM)  $@.tmp | $(PYTHON) hack/sha256sum.py -c > /dev/null
 	@mv $@.tmp $@
 
 PYTHON_VIRTUALENV = $(SHELL_ENV)/$(shell basename $(PYTHON_VIRTUALENV_SRC) .tar.gz)
@@ -61,7 +61,7 @@ $(KUBECTL_BIN): $(SHELL_ENV_EXISTS)
 	@rm -f $@.tmp
 	@echo "Downloading kubectl..."
 	@$(PYTHON) hack/download.py $(KUBECTL_SRC) $@.tmp
-	@echo $(KUBECTL_SRC_SHA256SUM)  $@.tmp | sha256sum -c > /dev/null
+	@echo $(KUBECTL_SRC_SHA256SUM)  $@.tmp | $(PYTHON) hack/sha256sum.py -c > /dev/null
 	@chmod a+x $@.tmp
 	@mv $@.tmp $@
 
@@ -74,14 +74,14 @@ $(HELM_SRC_TAR): $(SHELL_ENV_EXISTS)
 	@rm -f $@.tmp
 	@echo "Downloading Helm..."
 	@$(PYTHON) hack/download.py $(HELM_SRC) $@.tmp
-	@echo $(HELM_SRC_SHA256SUM)  $@.tmp | sha256sum -c > /dev/null
+	@echo $(HELM_SRC_SHA256SUM)  $@.tmp | $(PYTHON) hack/sha256sum.py -c > /dev/null
 	@mv $@.tmp $@
 
 HELM_BIN = $(SHELL_ENV)/helm-$(HELM_VERSION)
 $(HELM_BIN): $(HELM_SRC_TAR) $(SHELL_ENV_EXISTS)
 	@rm -f $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm
 	@tar -xf $(HELM_SRC_TAR) -C $(SHELL_ENV) $(UNAME_KERNEL)-$(UNAME_MACHINE)/helm
-	@echo $(HELM_BIN_SHA256SUM)  $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm | sha256sum -c > /dev/null
+	@echo $(HELM_BIN_SHA256SUM)  $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm | $(PYTHON) hack/sha256sum.py -c > /dev/null
 	@mv $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm $@
 
 HELM = $(VENV_BIN)/helm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 .POSIX:
 
+MAKEFLAGS += -r
+.DEFAULT_GOAL := default
+.DELETE_ON_ERROR:
+.SUFFIXES:
+
+default: help
+.PHONY: default
+
 VIRTUALENV_SRC = https://files.pythonhosted.org/packages/b1/72/2d70c5a1de409ceb3a27ff2ec007ecdd5cc52239e7c74990e32af57affe9/virtualenv-15.2.0.tar.gz
 VIRTUALENV_SRC_SHA256SUM = 1d7e241b431e7afce47e77f8843a276f652699d1fa4f93b9d8ce0076fd7b0b54
 
@@ -110,11 +118,17 @@ $(BASHRC): $(SHELL_ENV_EXISTS) hack/shell-bashrc
 	$(V)rm -f $@
 	$(V)sed s:@VENV_ACTIVATE@:$(VENV_ACTIVATE):g < hack/shell-bashrc > $@ || (rm -f $@; exit 1)
 
-shell: $(VENV_EXISTS) $(REQUIREMENTS_INSTALLED) $(KUBECTL) $(HELM) $(BASHRC)
+shell: $(VENV_EXISTS) $(REQUIREMENTS_INSTALLED) $(KUBECTL) $(HELM) $(BASHRC) ## Run a shell with `ansible-playbook`, `kubectl` and `helm` pre-installed
 	$(V)echo "Launching metal-k8s shell environment. Run 'exit' to quit."
 	$(V)bash --rcfile $(BASHRC) ||:
 .PHONY: shell
 
-clean-shell:
+clean-shell: ## Clean-up the `shell` environment
 	$(V)rm -rf $(SHELL_ENV)
 .PHONY: clean-shell
+
+help: ## Show this help message
+	$(V)echo "The following targets are available:"
+	$(V)echo
+	$(V)grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+.PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,56 @@
 .POSIX:
 
-VIRTUALENV_SRC := https://files.pythonhosted.org/packages/b1/72/2d70c5a1de409ceb3a27ff2ec007ecdd5cc52239e7c74990e32af57affe9/virtualenv-15.2.0.tar.gz
-VIRTUALENV_SRC_SHA256SUM := 1d7e241b431e7afce47e77f8843a276f652699d1fa4f93b9d8ce0076fd7b0b54
+VIRTUALENV_SRC = https://files.pythonhosted.org/packages/b1/72/2d70c5a1de409ceb3a27ff2ec007ecdd5cc52239e7c74990e32af57affe9/virtualenv-15.2.0.tar.gz
+VIRTUALENV_SRC_SHA256SUM = 1d7e241b431e7afce47e77f8843a276f652699d1fa4f93b9d8ce0076fd7b0b54
 
-KUBECTL_VERSION := 1.10.1
-KUBECTL_SRC_SHA256SUM := 1bb4d3793fb0f9e1cfee86599e0f43ae5f15578a01b61011fe7c9488e114a00b
+KUBECTL_VERSION = 1.10.1
+KUBECTL_BIN_SHA256SUM.linux = 1bb4d3793fb0f9e1cfee86599e0f43ae5f15578a01b61011fe7c9488e114a00b
+KUBECTL_BIN_SHA256SUM.darwin = 9484fd8a0cba513ab91fc192f6b6659d700f411502d01a7e02acb9f3b986037c
 
-HELM_VERSION := 2.8.2
-HELM_SRC_SHA256SUM := 614b5ac79de4336b37c9b26d528c6f2b94ee6ccacb94b0f4b8d9583a8dd122d3
-HELM_BIN_SHA256SUM := 0521956fa22be33189cc825bb27b3f4178c5ce9a448368b5c81508d446472715
+HELM_VERSION = 2.8.2
+HELM_SRC_SHA256SUM.linux = 614b5ac79de4336b37c9b26d528c6f2b94ee6ccacb94b0f4b8d9583a8dd122d3
+HELM_SRC_SHA256SUM.darwin = a0a8cf462080b2bc391f38b7cf617618b189cdef9f071c06fa0068c2418cc413
+HELM_BIN_SHA256SUM.linux = 0521956fa22be33189cc825bb27b3f4178c5ce9a448368b5c81508d446472715
+HELM_BIN_SHA256SUM.darwin = 49c0f595f1c02c466191aa41143d623b553cc0d1fc2c92ab41984699aa3d0317
 
-UNAME_KERNEL = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-UNAME_MACHINE = $(shell uname -m | sed 's/^x86_64$$/amd64/')
+V=@
 
-KUBECTL_SRC := https://storage.googleapis.com/kubernetes-release/release/v$(KUBECTL_VERSION)/bin/$(UNAME_KERNEL)/$(UNAME_MACHINE)/kubectl
-HELM_SRC := https://storage.googleapis.com/kubernetes-helm/helm-v$(HELM_VERSION)-$(UNAME_KERNEL)-$(UNAME_MACHINE).tar.gz
+uname_kernel = uname -s | tr '[:upper:]' '[:lower:]'
+uname_machine = uname -m | sed 's/^x86_64$$/amd64/'
+UNAME_KERNEL = $(shell $(uname_kernel))$(uname_kernel:sh)
+UNAME_MACHINE = $(shell $(uname_machine))$(uname_machine:sh)
 
-PYTHON := python
+KUBECTL_SRC = https://storage.googleapis.com/kubernetes-release/release/v$(KUBECTL_VERSION)/bin/$(UNAME_KERNEL)/$(UNAME_MACHINE)/kubectl
+KUBECTL_BIN_SHA256SUM = $(KUBECTL_BIN_SHA256SUM.$(UNAME_KERNEL))
+HELM_SRC = https://storage.googleapis.com/kubernetes-helm/helm-v$(HELM_VERSION)-$(UNAME_KERNEL)-$(UNAME_MACHINE).tar.gz
+HELM_SRC_SHA256SUM = $(HELM_SRC_SHA256SUM.$(UNAME_KERNEL))
+HELM_BIN_SHA256SUM = $(HELM_BIN_SHA256SUM.$(UNAME_KERNEL))
 
-SHELL_ENV := .shell-env
+PYTHON = python
+
+SHELL_ENV = .shell-env
 
 SHELL_ENV_EXISTS = $(SHELL_ENV)/.exists
 $(SHELL_ENV_EXISTS):
-	@mkdir -p $(shell dirname $@)
-	@touch $@
+	$(V)mkdir -p $(SHELL_ENV)
+	$(V)touch $@
 
-PYTHON_VIRTUALENV_SRC = $(SHELL_ENV)/$(shell basename $(VIRTUALENV_SRC))
+VIRTUALENV_SRC_BASENAME = basename $(VIRTUALENV_SRC)
+PYTHON_VIRTUALENV_SRC = $(SHELL_ENV)/$(shell $(VIRTUALENV_SRC_BASENAME))$(VIRTUALENV_SRC_BASENAME:sh)
 $(PYTHON_VIRTUALENV_SRC): $(SHELL_ENV_EXISTS)
-	@rm -f $@.tmp
-	@$(PYTHON) hack/download.py $(VIRTUALENV_SRC) $@.tmp
-	@echo $(VIRTUALENV_SRC_SHA256SUM)  $@.tmp | $(PYTHON) hack/sha256sum.py -c > /dev/null
-	@mv $@.tmp $@
+	$(V)rm -f $@.tmp
+	$(V)$(PYTHON) hack/download.py $(VIRTUALENV_SRC) $@.tmp
+	$(V)echo $(VIRTUALENV_SRC_SHA256SUM)  $@.tmp | $(PYTHON) hack/sha256sum.py -c > /dev/null
+	$(V)mv $@.tmp $@
 
-PYTHON_VIRTUALENV = $(SHELL_ENV)/$(shell basename $(PYTHON_VIRTUALENV_SRC) .tar.gz)
+PYTHON_VIRTUALENV_SRC_BASENAME = basename $(PYTHON_VIRTUALENV_SRC) .tar.gz
+PYTHON_VIRTUALENV_SRC_DIRNAME = dirname $(PYTHON_VIRTUALENV)
+PYTHON_VIRTUALENV = $(SHELL_ENV)/$(shell $(PYTHON_VIRTUALENV_SRC_BASENAME))$(PYTHON_VIRTUALENV_SRC_BASENAME:sh)
 PYTHON_VIRTUALENV_EXISTS = $(PYTHON_VIRTUALENV)/.exists
 $(PYTHON_VIRTUALENV_EXISTS): $(SHELL_ENV_EXISTS) $(PYTHON_VIRTUALENV_SRC)
-	@rm -rf $(PYTHON_VIRTUALENV)
-	@tar -xf $(PYTHON_VIRTUALENV_SRC) -C $(shell dirname $(PYTHON_VIRTUALENV))
-	@touch $@
+	$(V)rm -rf $(PYTHON_VIRTUALENV)
+	$(V)tar -xf $(PYTHON_VIRTUALENV_SRC) -C $(shell $(PYTHON_VIRTUALENV_SRC_DIRNAME))$(PYTHON_VIRTUALENV_SRC_DIRNAME:sh)
+	$(V)touch $@
 
 VENV = $(SHELL_ENV)/metal-k8s
 VENV_BIN = $(VENV)/bin
@@ -45,59 +58,63 @@ VENV_ACTIVATE = $(VENV_BIN)/activate
 
 VENV_EXISTS = $(VENV)/.exists
 $(VENV_EXISTS): $(PYTHON_VIRTUALENV_EXISTS)
-	@rm -rf $(VENV)
-	@echo "Creating virtualenv..."
-	@PYTHONPATH=$(PYTHON_VIRTUALENV) $(PYTHON) -m virtualenv $(VENV) > /dev/null
-	@touch $@
+	$(V)rm -rf $(VENV)
+	$(V)echo "Creating virtualenv..."
+	$(V)PYTHONPATH=$(PYTHON_VIRTUALENV) $(PYTHON) -m virtualenv $(VENV) > /dev/null
+	$(V)touch $@
 
 REQUIREMENTS_INSTALLED = $(SHELL_ENV)/.requirements_installed
 $(REQUIREMENTS_INSTALLED): $(VENV_EXISTS) requirements.txt
-	@echo "Installing Python dependencies..."
-	@. $(VENV_ACTIVATE) && pip install -r requirements.txt > /dev/null
-	@touch $@
+	$(V)echo "Installing Python dependencies..."
+	$(V). $(VENV_ACTIVATE) && pip install -r requirements.txt > /dev/null
+	$(V)touch $@
 
 KUBECTL_BIN = $(SHELL_ENV)/kubectl-$(KUBECTL_VERSION)
 $(KUBECTL_BIN): $(SHELL_ENV_EXISTS)
-	@rm -f $@.tmp
-	@echo "Downloading kubectl..."
-	@$(PYTHON) hack/download.py $(KUBECTL_SRC) $@.tmp
-	@echo $(KUBECTL_SRC_SHA256SUM)  $@.tmp | $(PYTHON) hack/sha256sum.py -c > /dev/null
-	@chmod a+x $@.tmp
-	@mv $@.tmp $@
+	$(V)rm -f $@.tmp
+	$(V)echo "Downloading kubectl..."
+	$(V)$(PYTHON) hack/download.py $(KUBECTL_SRC) $@.tmp
+	$(V)echo $(KUBECTL_BIN_SHA256SUM)  $@.tmp | $(PYTHON) hack/sha256sum.py -c > /dev/null
+	$(V)chmod a+x $@.tmp
+	$(V)mv $@.tmp $@
 
 KUBECTL = $(VENV_BIN)/kubectl
+KUBECTL_REALPATH = realpath $(KUBECTL_BIN)
 $(KUBECTL): $(KUBECTL_BIN) $(VENV_EXISTS)
-	@ln -sf $(shell realpath $(KUBECTL_BIN)) $@
+	$(V)ln -sf $(shell $(KUBECTL_REALPATH))$(KUBECTL_REALPATH:sh) $@
 
-HELM_SRC_TAR = $(SHELL_ENV)/$(shell basename $(HELM_SRC))
+HELM_SRC_BASENAME = basename $(HELM_SRC)
+HELM_SRC_TAR = $(SHELL_ENV)/$(shell $(HELM_SRC_BASENAME))$(HELM_SRC_BASENAME:sh)
 $(HELM_SRC_TAR): $(SHELL_ENV_EXISTS)
-	@rm -f $@.tmp
-	@echo "Downloading Helm..."
-	@$(PYTHON) hack/download.py $(HELM_SRC) $@.tmp
-	@echo $(HELM_SRC_SHA256SUM)  $@.tmp | $(PYTHON) hack/sha256sum.py -c > /dev/null
-	@mv $@.tmp $@
+	$(V)rm -f $@.tmp
+	$(V)echo "Downloading Helm..."
+	$(V)$(PYTHON) hack/download.py $(HELM_SRC) $@.tmp
+	$(V)echo $(HELM_SRC_SHA256SUM)  $@.tmp | $(PYTHON) hack/sha256sum.py -c > /dev/null
+	$(V)mv $@.tmp $@
 
 HELM_BIN = $(SHELL_ENV)/helm-$(HELM_VERSION)
 $(HELM_BIN): $(HELM_SRC_TAR) $(SHELL_ENV_EXISTS)
-	@rm -f $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm
-	@tar -xf $(HELM_SRC_TAR) -C $(SHELL_ENV) $(UNAME_KERNEL)-$(UNAME_MACHINE)/helm
-	@echo $(HELM_BIN_SHA256SUM)  $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm | $(PYTHON) hack/sha256sum.py -c > /dev/null
-	@mv $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm $@
+	$(V)rm -f $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm
+	$(V)tar -xf $(HELM_SRC_TAR) -C $(SHELL_ENV) $(UNAME_KERNEL)-$(UNAME_MACHINE)/helm
+	$(V)echo $(HELM_BIN_SHA256SUM)  $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm | $(PYTHON) hack/sha256sum.py -c > /dev/null
+	$(V)mv $(SHELL_ENV)/$(UNAME_KERNEL)-$(UNAME_MACHINE)/helm $@
+	$(V)touch $@
 
 HELM = $(VENV_BIN)/helm
+HELM_REALPATH = realpath $(HELM_BIN)
 $(HELM): $(HELM_BIN) $(VENV_EXISTS)
-	@ln -sf $(shell realpath $(HELM_BIN)) $@
+	$(V)ln -sf $(shell $(HELM_REALPATH))$(HELM_REALPATH:sh) $@
 
 BASHRC = $(SHELL_ENV)/bashrc
 $(BASHRC): $(SHELL_ENV_EXISTS) hack/shell-bashrc
-	@rm -f $@
-	@sed s:@VENV_ACTIVATE@:$(VENV_ACTIVATE):g < hack/shell-bashrc > $@ || (rm -f $@; exit 1)
+	$(V)rm -f $@
+	$(V)sed s:@VENV_ACTIVATE@:$(VENV_ACTIVATE):g < hack/shell-bashrc > $@ || (rm -f $@; exit 1)
 
 shell: $(VENV_EXISTS) $(REQUIREMENTS_INSTALLED) $(KUBECTL) $(HELM) $(BASHRC)
-	@echo "Launching metal-k8s shell environment. Run 'exit' to quit."
-	@bash --rcfile $(BASHRC) ||:
+	$(V)echo "Launching metal-k8s shell environment. Run 'exit' to quit."
+	$(V)bash --rcfile $(BASHRC) ||:
 .PHONY: shell
 
 clean-shell:
-	@rm -rf $(SHELL_ENV)
+	$(V)rm -rf $(SHELL_ENV)
 .PHONY: clean-shell

--- a/hack/sha256sum.py
+++ b/hack/sha256sum.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import sys
+import hashlib
+
+def main():
+    assert len(sys.argv) == 2
+    assert sys.argv[1] == '-c'
+
+    for line in sys.stdin.readlines():
+        line = line.rstrip('\n')
+        if line == '':
+            break
+
+        [checksum, path] = line.split(None, 1)
+
+        with open(path, 'rb') as fd:
+            sha256 = hashlib.sha256()
+
+            while True:
+                data = fd.read(32 * 1024)
+                if len(data) == 0:
+                    break
+                sha256.update(data)
+
+            if sha256.hexdigest() != checksum:
+                raise Exception('Checksum mismatch')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Since MacOS X doesn't come with `sha256sum` by default, replace it with a bare-bones Python implementation
- Add checksums for MacOS X versions of binary packages, and pick the right one to compare against
- Make `Makefile` more portable (tested with GNU Make/Bash, GNU Make/Dash, `bmake`/Bash and `bmake`/Dash)
- Add a `make help` target, also the default