### PR TITLE
Improvement/use existing vg

### DIFF
--- a/roles/kube_lvm_storage/tasks/main.yml
+++ b/roles/kube_lvm_storage/tasks/main.yml
@@ -1,3 +1,11 @@
+- name: 'Check that you have mkfs for ext4 and xfs filesystem'
+  package:
+    name: '{{ item }}'
+    state: present
+  with_items:
+    - e2fsprogs
+    - xfsprogs
+
 - name: 'Assert all vgs have a host_path and volumes defined'
   assert:
     that:

--- a/roles/setup_lvm/defaults/main.yml
+++ b/roles/setup_lvm/defaults/main.yml
@@ -8,4 +8,9 @@ debug: False
 metal_k8s_lvm:
   vgs:
     kubevg:
+      # The list of drives used for this LVM Volume Group. Leave empty and set 
+      # create to 'False' if you want to use an already existing Volume Group
       drives: []
+      # Put this to False if you want to use
+      # an already existing LVM Volume Group
+      create: True

--- a/roles/setup_lvm/tasks/main.yml
+++ b/roles/setup_lvm/tasks/main.yml
@@ -1,7 +1,10 @@
 - name: "LVM Setup: Assert {{ inventory_hostname }} has vgs correctly declared"
   assert:
     that:
-      - 'item.value.drives|length > 0'
+      - '(item.value.drives|length > 0
+            and item.value.create|default(True)|bool)
+        or (item.value.drives|length == 0
+            and not item.value.create|default(True)|bool)'
   with_dict: '{{ metal_k8s_lvm.vgs }}'
 
 - name: "LVM Setup: Check LVM packages"
@@ -20,3 +23,5 @@
     vg: '{{ item.key }}'
     state: present
   with_dict: '{{ metal_k8s_lvm.vgs }}'
+  when:
+    - 'item.value.create|default(True)|bool'


### PR DESCRIPTION
* Add a configuration item under the VG setup to use an existing one, preventing any drive declation
* Also ensure before FS creation that ext4 and xfs tools are here.

Tested with the following group_vars/kube-node/00-storage.yml with an existing VG
```
# LVM confguration
# Specify which VG and which drive to use in host_vars for each node
metal_k8s_lvm:
  vgs:
    kubevg:
      drives: []
      create: False
```

Still to do:
* check that the "drive", if raw device, do not have existing partition
* if the drive is a partition, check that there is no "links" to it so we don't risk to destroy anything
```
"vdc": {
                "holders": [],
                "host": "",
                "links": {
                    "ids": [
                        "virtio-72901dae-e9b5-4e59-b"
                    ],
                    "labels": [],
                    "masters": [],
                    "uuids": []
                },
                "model": null,
                "partitions": {
                    "vdc1": {
                        "holders": [],
                        "links": {
                            "ids": [
                                "lvm-pv-uuid-dAcGns-VENL-X2CT-ixHo-Td3Z-OME5-ZKOGFA",
                                "virtio-72901dae-e9b5-4e59-b-part1"
                            ],
                            "labels": [],
                            "masters": [],
                            "uuids": []
                        },
                        "sectors": "2093056",
                        "sectorsize": 512,
                        "size": "1022.00 MB",
                        "start": "2048",
                        "uuid": null
                    }
                },
                "removable": "0",
                "rotational": "1",
                "sas_address": null,
                "sas_device_handle": null,
                "scheduler_mode": "",
                "sectors": "2097152",
                "sectorsize": "512",
                "size": "1.00 GB",
                "support_discard": "0",
                "vendor": "0x1af4",
                "virtual": 1
            }
```
