### PR TITLE
Ping all nodes at playbook start, and re-align `scale` playbook

### DIFF
--- a/metal-k8s.yml
+++ b/metal-k8s.yml
@@ -6,7 +6,7 @@
   tags:
     - preflight-checks
 
-- hosts: k8s-cluster
+- hosts: k8s-cluster:etcd
   gather_facts: False
   tasks:
     - ping:

--- a/scale-metal-k8s.yml
+++ b/scale-metal-k8s.yml
@@ -1,7 +1,19 @@
+- hosts: localhost
+  gather_facts: False
+  any_errors_fatal: True
+  roles:
+    - role: preflight_checks
+  tags:
+    - preflight-checks
+
 - hosts: k8s-cluster:etcd
   gather_facts: False
   tasks:
     - ping:
+
+- hosts: k8s-cluster:etcd
+  roles:
+    - role: check_os
 
 - hosts: kube-node
   tags:

--- a/scale-metal-k8s.yml
+++ b/scale-metal-k8s.yml
@@ -1,4 +1,4 @@
-- hosts: kube-node
+- hosts: k8s-cluster:etcd
   gather_facts: False
   tasks:
     - ping:


### PR DESCRIPTION
See #37 

Also, we should find a way to easier keep the `main` playbook and the `scale` playbook in sync. Using tags, maybe? Pinging @Zempashi @alxf @ballot-scality 