### PR TITLE
Disable anonymous read-only API port

### DIFF
--- a/group_vars/k8s-cluster/10-metal-k8s.yml
+++ b/group_vars/k8s-cluster/10-metal-k8s.yml
@@ -6,9 +6,6 @@ kubeconfig_localhost: True
 kubelet_authentication_token_webhook: True
 kube_api_pwd: "{{ lookup('password', playbook_dir + '/credentials/kube_user length=15 chars=ascii_letters,digits') }}"
 
-# Currently required for Heapster kubelet access
-kube_read_only_port: 10255
-
 # Request usage of the `overlay2` storage driver, even on pre-18.03 Docker
 # installs.
 # Whilst this is not guaranteed to work on 'old' kernels, we check whether we're

--- a/roles/kube_heapster/files/values.yml
+++ b/roles/kube_heapster/files/values.yml
@@ -1,2 +1,9 @@
 rbac:
   create: true
+
+command:
+- "/heapster"
+# Chart default:
+# - "--source=kubernetes.summary_api:''"
+# For https://github.com/scality/metal-k8s/issues/36:
+- "--source=kubernetes.summary_api:''?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250&insecure=true"

--- a/roles/kube_metrics_server/files/metrics-server-deployment.yaml
+++ b/roles/kube_metrics_server/files/metrics-server-deployment.yaml
@@ -28,4 +28,7 @@ spec:
         imagePullPolicy: Always
         command:
         - /metrics-server
-        - --source=kubernetes.summary_api:''
+        # Default:
+        #- --source=kubernetes.summary_api:''
+        # For https://github.com/scality/metal-k8s/issues/36:
+        - "--source=kubernetes.summary_api:''?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250&insecure=true"


### PR DESCRIPTION
This commit disables the anonymous (non-authenticated) read-only API
port, which is insecure, and adjusts the Heapster and `metrics-server`
configuration to take this into account.

Fixes: #36
Fixes: https://github.com/scality/metal-k8s/issues/36
See: https://github.com/kubernetes-incubator/kubespray/issues/2550#issuecomment-377145148
See: 71206ef027347d4386f0109aa88848929c10a42c
See: https://github.com/scality/metal-k8s/commit/71206ef027347d4386f0109aa88848929c10a42c#diff-384fbcda7fecbabd124cf2ccae3167cdR9