### PR TITLE
docs: Update Dashboard access instructions

### DIFF
--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -152,9 +152,10 @@ Access to dashboard, Grafana and Kibana
 Once the cluster is running, you can access the `Kubernetes dashboard`_,
 Grafana_ metrics and Kibana_ logs from your browser.
 
-The Kubernetes dashboard is available at :samp:`https://{master-ip}:6443/ui`,
-where *master-ip* should be replaced by the IP-address of one of the hosts in
-the *kube-master* group.
+To access the Kubernetes dashboard, first create a secure tunnel into your
+cluster by running ``kubectl proxy``. Then, while the tunnel is up and running,
+access the dashboard at
+http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/.
 
 Grafana can be accessed at :samp:`http://{node-ip}/_/grafana`, with *node-ip*
 replaced by the IP-address of one of the hosts in the *kube-node* group.


### PR DESCRIPTION
After the update to Kubernetes 1.10, the `/ui` shorthand to access the
Dashboard through a `kube-master` node is no longer available. This
commit updates the documentation to instead use `kubectl proxy` and a
`localhost` URL.

See: 12b864acc5ec791a2fb13730c872d30a5839d3b0
See: https://github.com/scality/metal-k8s/pull/59#issuecomment-390362025
See: https://github.com/scality/metal-k8s/pull/59#issuecomment-390397977