### PR TITLE
Node selector use nodename instead of hostname. Use 1.10 API

### DIFF
--- a/roles/kube_lvm_storage/templates/local-pv.yml.j2
+++ b/roles/kube_lvm_storage/templates/local-pv.yml.j2
@@ -3,18 +3,6 @@ kind: PersistentVolume
 metadata:
   name: >-
     {{ item.value.vg|replace("_","-") }}-{{ item.value.volume.uuid }}
-  annotations:
-    "volume.alpha.kubernetes.io/node-affinity": ' {
-        "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-                { "matchExpressions": [
-                    { "key": "kubernetes.io/hostname",
-                      "operator": "In",
-                      "values": ["{{ ansible_hostname }}"]
-                    }
-                ]}
-             ]}
-          }'
 spec:
   capacity:
     storage: '{{ item.value.volume.size|size_lvm_to_k8s }}'
@@ -24,3 +12,11 @@ spec:
   storageClassName: '{{ item.value.storage_class }}'
   local:
     path: '{{ item.value.host_path }}/{{ item.value.volume.uuid }}'
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - '{{ ansible_nodename }}'


### PR DESCRIPTION
On AWS:
kubernetes.io/hostname: `ip-172-16-57-244.eu-west-2.compute.internal`
ansible_hostname: `ip-172-16-57-244`
ansible_nodename: `ip-172-16-57-244.eu-west-2.compute.internal`

On scality.cloud:
kubernetes.io/hostname: `kube-01`
ansible_hostname: `kube-01`
ansible_nodename: `kube-01`